### PR TITLE
Update this tool to work with Juno

### DIFF
--- a/nova/auto-fix-quota-all-tenants.sh
+++ b/nova/auto-fix-quota-all-tenants.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-#source /root/scripts/stackrc
 
 echo "$(date): Tenant quota correction - started"
 
-for x in $(openstack project list -f csv -c ID | tail -n +2);
+for x in $(openstack project list -f csv -c ID --quote none | tail -n +2);
 do
-   echo "Correcting quota for tenant $x"
-   ./auto-fix-quota.py --dryrun --tenant $x 
-   echo
+   #echo "Correcting quota for tenant $x"
+   ./auto-fix-quota.py --quiet --dryrun --tenant $x 
+   #echo
 done
 
 echo "$(date): Tenant quota correction - finished"

--- a/nova/auto-fix-quota-all-tenants.sh
+++ b/nova/auto-fix-quota-all-tenants.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-source /root/scripts/stackrc
+#source /root/scripts/stackrc
 
 echo "$(date): Tenant quota correction - started"
 
-for x in $(keystone --insecure tenant-list | awk -F' | ' '!/^\+/ && !/\ id\ / {print $2}');
+for x in $(openstack project list -f csv -c ID | tail -n +2);
 do
    echo "Correcting quota for tenant $x"
-   python /root/scripts/auto-fix-quota.py --tenant $x
+   ./auto-fix-quota.py --dryrun --tenant $x 
+   echo
 done
 
 echo "$(date): Tenant quota correction - finished"

--- a/nova/auto-fix-quota.py
+++ b/nova/auto-fix-quota.py
@@ -11,8 +11,6 @@ from nova import exception
 from collections import OrderedDict
 import argparse
 import prettytable
-import bpdb
-
 
 def make_table(name, *args):
     q = prettytable.PrettyTable(name)


### PR DESCRIPTION
This set of changes updates the auto-fix-quota tool for Juno. This wasn't a simple fix because the original code appears to be from the Grizzly era and so doesn't have to handle quota usage per user (in addition to the existing per tenant usage).

The changes ended up being on nearly every line, so perhaps there is little value in reviewing the changes so much as the end result.

There are some additional notes in the commit messages.
